### PR TITLE
グループの編集機能の実装

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,4 +1,5 @@
 class GroupsController < ApplicationController
+  before_action :set_group, only: [:edit, :update]
   def index
   end
   
@@ -16,8 +17,20 @@ class GroupsController < ApplicationController
     end
   end
 
+  def update
+    if @group.update(group_params)
+      redirect_to group_messages_path(@group), notice: 'グループを編集しました'
+    else
+      render :edit
+    end
+  end
+
   private
   def group_params
     params.require(:group).permit(:name, { :user_ids => [] })
+  end
+
+  def set_group
+    @group = Group.find(params[:id])
   end
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,0 +1,24 @@
+= form_for group do |f|
+  - if group.errors.any?
+    .chat-group-form__errors
+      %h2= "#{group.errors.full_messages.count}件のエラーが発生しました。"
+      %ul
+        - group.errors.full_messages.each do |message|
+          %li= message
+  .chat-group-form__field
+    .chat-group-form__field--left
+      = f.label :name, class: 'chat-group-form__label'
+    .chat-group-form__field--right
+      = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
+  .chat-group-form__field
+    / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
+  .chat-group-form__field
+    .chat-group-form__field--left
+      = f.label "チャットメンバー", class: "chat-group-form__label"
+    .chat-group-form__field--right
+      = f.collection_check_boxes :user_ids, User.all, :id, :name
+      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
+  .chat-group-form__field
+    .chat-group-form__field--left
+    .chat-group-form__field--right
+      = f.submit class: 'chat-group-form__action-btn'

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,25 +1,3 @@
 .chat-group-form
   %h1 チャットグループ編集
-  %form#edit_chat_group_22.edit_chat_group{"accept-charset" => "UTF-8", :action => "/chat_groups/22", :method => "post"}
-    .chat-group-form__errors
-      %h2
-        1件のエラーが発生しました。
-        %ul
-          %li エラーです
-    .chat-group-form__field
-      .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
-      .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text", value: "ほげー"}/
-    .chat-group-form__field
-      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
-      .chat-group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with":"Save", name: "commit", type: "submit", value: "Save"}/
+  = render partial: 'form', locals: { group: @group }

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,26 +1,3 @@
 .chat-group-form
   %h1 新規チャットグループ
-  = form_for @group do |f|
-    - if @group.errors.any?
-      .chat-group-form__errors
-        %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
-        %ul
-          - @group.errors.full_messages.each do |message|
-            %li= message
-    .chat-group-form__field
-      .chat-group-form__field--left
-        = f.label :name, class: 'chat-group-form__label'
-      .chat-group-form__field--right
-        = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
-    .chat-group-form__field
-      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-        = f.label "チャットメンバー", class: "chat-group-form__label"
-      .chat-group-form__field--right
-        = f.collection_check_boxes :user_ids, User.all, :id, :name
-        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        = f.submit class: 'chat-group-form__action-btn'
+  = render 'form', { group: @group }

--- a/app/views/messages/_group.html.haml
+++ b/app/views/messages/_group.html.haml
@@ -1,8 +1,0 @@
-.groups
-  - current_user.groups.each do |group|
-    = link_to '#', class: "groups__group-link" do
-      .groups__group-link__group 
-        .groups__group-link__group__name
-          = group.name
-        .groups__group-link__group__message
-          メッセージはまだありません。

--- a/app/views/messages/_sidebar.html.haml
+++ b/app/views/messages/_sidebar.html.haml
@@ -10,4 +10,11 @@
         %li.chat-side__header__user-box__menu__user-account
           = link_to edit_user_path(current_user) do
             = fa_icon 'cog', class: "fa-cog"
-  = render partial: "messages/group"
+  .groups
+    - current_user.groups.each do |group|
+      = link_to group_messages_path(group), class: "groups__group-link" do
+        .groups__group-link__group 
+          .groups__group-link__group__name
+            = group.name
+          .groups__group-link__group__message
+            メッセージはまだありません。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  root 'messages#index'
+  root 'groups#index'
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]


### PR DESCRIPTION
# What
グループコントローラにupdateアクションを定義。
グループのビューであるnew、editの共通部分を_formというファイルに移し部分テンプレートで呼び出す形に変更。
ホームパスをgroups#indexに変更。

# Why
グループの実装に必要な機能のため