### PR TITLE
メッセージ送信機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,3 +55,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'haml-rails'
 gem 'font-awesome-rails'
 gem 'devise'
+gem 'carrierwave'
+gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,11 +38,20 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     arel (7.1.4)
     bcrypt (3.1.13)
     bindex (0.8.1)
     builder (3.2.3)
     byebug (11.0.1)
+    carrierwave (2.0.2)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      mimemagic (>= 0.3.0)
+      mini_mime (>= 0.1.3)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -81,6 +90,9 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
+    image_processing (1.9.3)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.13, < 3)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
     jquery-rails (4.3.5)
@@ -96,6 +108,8 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.9.2)
+    mimemagic (0.3.3)
+    mini_magick (4.9.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.12.2)
@@ -104,6 +118,7 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    public_suffix (4.0.1)
     puma (3.12.1)
     rack (2.0.7)
     rack-test (0.6.3)
@@ -138,6 +153,8 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    ruby-vips (2.0.16)
+      ffi (~> 1.9)
     ruby_parser (3.14.0)
       sexp_processor (~> 4.9)
     sass (3.7.4)
@@ -190,6 +207,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  carrierwave
   coffee-rails (~> 4.2)
   devise
   font-awesome-rails
@@ -197,6 +215,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
+  mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Things you may want to cover:
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|text|text||
-|image|text||
+|content|string||
+|image|string||
 |user|references|null: false, foreign_key: true|
 |group|references|null: false, foreign_key: true|
 ### Association

--- a/app/assets/stylesheets/chatsite.scss
+++ b/app/assets/stylesheets/chatsite.scss
@@ -117,7 +117,6 @@
         width: 100%;
         height: 50px;
         display: flex;
-        position: relative;
         &__textarea{
           height: 50px;
           width: 100%;
@@ -127,17 +126,20 @@
           border-style: none;
           font-size: 16px;
         }
-        &__photo{
-          display: inline-block;
-          position: absolute;
-          top: 15px;
-          right: 10px;
-          .fa{
-            font-size: 21px;
-            @include link-icon();
-          }
-          #message_image{
-            display: none; 
+        &__mask{
+          position: relative;
+          &__photo{
+            display: inline-block;
+            position: absolute;
+            top: 15px;
+            right: 10px;
+            .fa{
+              font-size: 21px;
+              @include link-icon();
+            }
+            #message_image{
+              display: none; 
+            }
           }
         }
       }

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,7 +1,29 @@
 class MessagesController < ApplicationController
+  before_action :set_group
+
   def index
+    @message = Message.new
+    @messages = @group.messages.includes(:user)
   end
 
   def create
+    @message = @group.messages.new(message_params)
+    if @message.save
+      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+    else
+      @messages = @group.messages.includes(:user)
+      flash.now[:alert] = 'メッセージを入力してください'
+      render :index
+    end
+  end
+
+  private
+
+  def message_params
+    params.require(:message).permit(:content, :image).merge(user_id: current_user.id)
+  end
+
+  def set_group
+    @group = Group.find(params[:group_id])
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,6 @@
 class Group < ApplicationRecord
   has_many :group_users
   has_many :users, through: :group_users
+  has_many :messages
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,4 @@
+class Message < ApplicationRecord
+  belongs_to :user
+  belongs_to :group
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,12 @@
 class Message < ApplicationRecord
   belongs_to :user
   belongs_to :group
+  mount_uploader :image, ImageUploader
+  validates :content_or_image, presence: true
+
+  private
+
+  def content_or_image
+    content.presence or image.presence
+  end
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,49 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+
+  process resize_to_fit: [800, 800]
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -17,11 +17,10 @@
     = render partial: "messages/message"
   .send
     .form
-      %form.text-box
-        %input.text-box__textarea{placeholder: "type a message", type: "text", name: "message[content]"}
-        %label.text-box__photo{for: "message_image"}
-          %i.fa.fa-image
-          %input#message_image.text-box__photo--image{type: "file", name: "message[image]"}
-      %input.submit-btn{type: "submit", nama: "commit", value: "Send"}
-
-
+      = form_for [@group, @message], {:html => {:class => "text-box"}} do |f|
+        = f.text_field :content, class: 'text-box__textarea', placeholder: 'type a message'
+        .text-box__mask
+          = f.label :image, class: 'text-box__mask__photo', for: "message_image" do
+            = fa_icon 'fa-image', class: 'fa fa-image'
+            = f.file_field :image, id: 'message_image'
+        = f.submit 'Send', class: 'submit-btn'

--- a/db/migrate/20191014043523_create_messages.rb
+++ b/db/migrate/20191014043523_create_messages.rb
@@ -1,0 +1,11 @@
+class CreateMessages < ActiveRecord::Migration[5.0]
+  def change
+    create_table :messages do |t|
+      t.string :content
+      t.string :image
+      t.references :user, foreign_key: true
+      t.references :group, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191012051137) do
+ActiveRecord::Schema.define(version: 20191014043523) do
 
   create_table "group_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "group_id"
@@ -26,6 +26,17 @@ ActiveRecord::Schema.define(version: 20191012051137) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_groups_on_name", unique: true, using: :btree
+  end
+
+  create_table "messages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "content"
+    t.string   "image"
+    t.integer  "user_id"
+    t.integer  "group_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_messages_on_group_id", using: :btree
+    t.index ["user_id"], name: "index_messages_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -44,4 +55,6 @@ ActiveRecord::Schema.define(version: 20191012051137) do
 
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"
+  add_foreign_key "messages", "groups"
+  add_foreign_key "messages", "users"
 end


### PR DESCRIPTION
# What
messageモデルを作成。contentカラム、imageカラム、references型でuser、groupカラムを持ったmessagesテーブルを作成。user、groupカラムには外部キー制約をかけた。
messagesテーブルに画像を保存できるよう、carrierwave、mini_magickの２つのgemをインストールさせた。画像を保存できるようuploaderファイルを作成。
messagesコントローラにindexアクション、createアクションを定義。indexアクションではn+1問題を解消するためincludes(:user)を記述。createアクションでは、メッセージが保存された場合と、保存に失敗した場合で条件分岐をさせた。

# Why
メッセージ送信機能を実装するため。
テキストも画像もない状態ではメッセージを保存できないようにするため、バリデーションを定義した。
