### PR TITLE
メッセージ送信の非同期化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ group :development, :test do
   gem 'rails-controller-testing'
   gem 'factory_bot_rails'
   gem 'faker'
-
+  gem 'pry-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
       image_processing (~> 1.1)
       mimemagic (>= 0.3.0)
       mini_mime (>= 0.1.3)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -126,6 +127,11 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.1)
     puma (3.12.1)
     rack (2.0.7)
@@ -248,6 +254,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)
+  pry-rails
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)
   rails-controller-testing

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,6 @@
 // about supported directives.
 //
 //= require jquery
-//= require rails_ujs
+//= require jquery_ujs
 //= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,6 @@
 // about supported directives.
 //
 //= require jquery
-//= require jquery_ujs
+//= require rails_ujs
 //= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -11,5 +11,11 @@ $(function() {
       processData: false,
       contentType: false
     })
+    .done(function(message) {
+      
+    })
+    .fail(function() {
+
+    })
   })
 })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function() {
   function buildHTML(message){
     let img = ""
     if (message.image !== null) {
-      let img = `<img src = "${ message.image }, class: 'messages__message__text__image'">`
+      img = `<img src = "${ message.image }", class: 'messages__message__text__image'">`
     }
     let text = ""
     if (message.content !== null) {
@@ -43,7 +43,9 @@ $(function() {
       let html = buildHTML(message);
       $('.messages').append(html)
       $('#message_content').val('')
+      $('#message_image').val('')
       $('.messages').scrollTop( $(".messages")[0].scrollHeight );
+      $(".submit-btn").prop("disabled", false);
     })
     .fail(function(message) {
       alert('送信できませんでした')

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -43,6 +43,7 @@ $(function() {
       let html = buildHTML(message);
       $('.messages').append(html)
       $('#message_content').val('')
+      $('.messages').scrollTop( $(".messages")[0].scrollHeight );
     })
     .fail(function(message) {
       alert('送信できませんでした')

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function() {
   function buildHTML(message){
     let img = ""
     if (message.image !== null) {
-      img = `<img src = "${ message.image }">`
+      let img = `<img src = "${ message.image }, class: 'messages__message__text__image'">`
     }
     let text = ""
     if (message.content !== null) {
@@ -21,9 +21,10 @@ $(function() {
                       <p class="messages__message__text__content">
                         ${ text }
                       </p>
-                    <image_tag ${ img }, class: 'messages__message__text__image >
+                    ${ img }
                   </div>
                 </div>`
+    return html
   }
 
   $('#new_message').on('submit', function(e){
@@ -40,7 +41,7 @@ $(function() {
     })
     .done(function(message) {
       let html = buildHTML(message);
-      $('#new_message').append(html)
+      $('.messages').append(html)
       $('#message_content').val('')
     })
     .fail(function(message) {

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,15 @@
+$(function() {
+  $('#new_message').on('submit', function(e){
+    e.preventDefault();
+    let formData = new FormData(this);
+    let url = $(this).attr('action')
+    $.ajax( {
+      url: url,
+      type: 'POST',
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+  })
+})

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -35,9 +35,8 @@ $(function() {
     })
     .done(function(message) {
       let html = buildHTML(message);
-      $('.messages').append(html)
-      $('#message_content').val('')
-      $('#message_image').val('')
+      $('.messages').append(html);
+      $('.text-box')[0].reset();
       $('.messages').scrollTop( $(".messages")[0].scrollHeight );
     })
     .fail(function(message) {

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -45,10 +45,12 @@ $(function() {
       $('#message_content').val('')
       $('#message_image').val('')
       $('.messages').scrollTop( $(".messages")[0].scrollHeight );
-      $(".submit-btn").prop("disabled", false);
     })
     .fail(function(message) {
       alert('送信できませんでした')
+    })
+    .always(function(message){
+      $(".submit-btn").prop("disabled", false);
     })
   })
 })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,35 @@
 $(function() {
+  function buildHTML(message){
+    let img = ""
+    if (message.image !== null) {
+      img = `<img src = "${ message.image }">`
+    }
+    let text = ""
+    if (message.content !== null) {
+      text = `${ message.content }`
+    }
+    let html = `<div class="messages__message" data-id="${ message.id }">
+                  <div class="messages__message__info">
+                    <div class="messages__message__info__user-name">
+                      ${ message.user_name }
+                    </div>
+                    <div class="messages__message__info__date">
+                      ${ message.date }
+                    </div>
+                  </div>
+                  <div class="messages__message__text">
+                      <p class="messages__message__text__content">
+                        ${ text }
+                      </p>
+                    <image_tag ${ img }, class: 'messages__message__text__image >
+                  </div>
+                </div>`
+  }
+
   $('#new_message').on('submit', function(e){
     e.preventDefault();
     let formData = new FormData(this);
-    let url = $(this).attr('action')
+    let url = (window.location.href);
     $.ajax( {
       url: url,
       type: 'POST',
@@ -12,10 +39,12 @@ $(function() {
       contentType: false
     })
     .done(function(message) {
-      
+      let html = buildHTML(message);
+      $('#new_message').append(html)
+      $('#message_content').val('')
     })
-    .fail(function() {
-
+    .fail(function(message) {
+      alert('送信できませんでした')
     })
   })
 })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,13 +1,7 @@
 $(function() {
   function buildHTML(message){
-    let img = ""
-    if (message.image !== null) {
-      img = `<img src = "${ message.image }", class: 'messages__message__text__image'">`
-    }
-    let text = ""
-    if (message.content !== null) {
-      text = `${ message.content }`
-    }
+    let img = (message.image !== null) ? `<img src = "${ message.image }", class: 'messages__message__text__image'">`: "";
+    let text = (message.content !== null) ? `${ message.content }`: "";
     let html = `<div class="messages__message" data-id="${ message.id }">
                   <div class="messages__message__info">
                     <div class="messages__message__info__user-name">

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -4,6 +4,7 @@ class MessagesController < ApplicationController
   def index
     @message = Message.new
     @messages = @group.messages.includes(:user)
+    @members = @group.users
   end
 
   def create

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html { render_to group_messages_path(@group), notice: 'メッセージが送信されました' }
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください'

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,7 +10,7 @@ class MessagesController < ApplicationController
     @message = @group.messages.new(message_params)
     if @message.save
       respond_to do |format|
-        format.html { render_to group_messages_path(params[:group_id]), notice: 'メッセージが送信されました' }
+        format.html { redirect_to group_messages_path(params[:group_id]), notice: 'メッセージが送信されました' }
         format.json
       end
     else

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,7 +10,7 @@ class MessagesController < ApplicationController
     @message = @group.messages.new(message_params)
     if @message.save
       respond_to do |format|
-        format.html { render_to group_messages_path(@group), notice: 'メッセージが送信されました' }
+        format.html { render_to group_messages_path(params[:group_id]), notice: 'メッセージが送信されました' }
         format.json
       end
     else

--- a/app/views/messages/_sidebar.html.haml
+++ b/app/views/messages/_sidebar.html.haml
@@ -12,7 +12,7 @@
             = fa_icon 'cog', class: "fa-cog"
   .groups
     - current_user.groups.each do |group|
-      = link_to group_messages_path(group), class: "groups__group-link" do
+      = link_to group_messages_path(group), class: "groups__group-link", data: {"turbolinks" => false} do
         .groups__group-link__group 
           .groups__group-link__group__name
             = group.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,3 @@
+json.content @message.content
+json.image @message.image
+json.user_id @message.user.id

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,5 @@
 json.id @message.id
 json.content @message.content
-json.image @message.image
+json.image @message.image.url
 json.date @message.created_at.strftime("%Y/%m/%d(%a) %H:%M")
 json.user_name @message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,3 +1,5 @@
+json.id @message.id
 json.content @message.content
 json.image @message.image
-json.user_id @message.user.id
+json.date @message.created_at.strftime("%Y/%m/%d(%a) %H:%M")
+json.user_name @message.user.name

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -22,4 +22,4 @@
           = f.label :image, class: 'text-box__mask__photo', for: "message_image" do
             = fa_icon 'fa-image', class: 'fa fa-image'
             = f.file_field :image, id: 'message_image'
-            = f.submit 'Send', class: 'submit-btn'
+        = f.submit 'Send', class: 'submit-btn'

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -3,14 +3,13 @@
   .main-header
     .main-header__group-box
       %h2.main-header__group-box__group-title
-        グループ名
+        = @group.name
       %ul.main-header__group-box__member
         Member：
-        %li.main-header__group-box__member
-          Guest1
-        %li.main-header__group-box__member
-          Guest2
-    = link_to "https://www.google.co.jp/", class: "main-header__edit-btn" do
+        - @members.each do |member|
+          %li.main-header__group-box__member
+            = member.name
+    = link_to edit_group_path(params[:group_id]), class: "main-header__edit-btn" do
       .main-header__edit-btn__text
         Edit
   .messages
@@ -23,4 +22,4 @@
           = f.label :image, class: 'text-box__mask__photo', for: "message_image" do
             = fa_icon 'fa-image', class: 'fa fa-image'
             = f.file_field :image, id: 'message_image'
-        = f.submit 'Send', class: 'submit-btn'
+            = f.submit 'Send', class: 'submit-btn'

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,6 @@ module ChatSpace
       g.test_framework false
     end
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
   end
 end


### PR DESCRIPTION
# What
messageコントローラのcreateアクションが呼ばれた際、respond_toでjsonでの伝達回路を設定。
message.jsファイルを作成し、非同期でメッセージの送信をできるようにした。
message.jsで生成するデータはjbuilderを利用したため、create.json.jbuilderファイルを作成した。
メッセージを送信した後、フォームに残ったテキストと、画像が消えるようにした。
メッセージ投稿と同時に投稿したメッセージ部分までスクロールする。
サブミットボタンは何度でも押せるようにした。
送信できなかった場合はアラートを表示する。
group_messages_path(group)へのリンクに対し、turbolinksをオフにした

# Why
メッセージの送信を非同期で行えるようにするため
ターボリンクスオフ確認
![ターボリンクスオフ](https://user-images.githubusercontent.com/56216409/67154986-92ed6a00-f340-11e9-8a81-02f2ccc89ab3.gif)
画像投稿確認
![画像の投稿](https://user-images.githubusercontent.com/56216409/67154987-92ed6a00-f340-11e9-923f-c128593c4e0c.gif)
連続投稿、アラート確認
![連続投稿、アラート](https://user-images.githubusercontent.com/56216409/67154988-92ed6a00-f340-11e9-879a-a152bd5551fd.gif)



