### PR TITLE
グループ作成機能にインクリメンタルサーチを実装

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -2,6 +2,14 @@ $(function() {
   let search_list = $("#user-search-result");
   let group_list = $("#user-group-result");
 
+  function addUserId(user_ids) {
+    $('.group-member').each(function(i,user_id) {
+      let id = $(user_id).val();
+      user_ids.push(id);
+    });
+    return user_ids;
+  }
+
   function appendUser(user) {
     let html = `<div class="chat-group-user clearfix">
                   <p class="chat-group-user__name">${ user.name }</p>
@@ -17,9 +25,9 @@ $(function() {
     search_list.append(html);
   }
 
-  function appendGroup(name, id) {
+  function GroupUser(name, id) {
     let html = `<div class='chat-group-user'>
-                <input name='group[user_ids][]' type='hidden' value='${ id }'>
+                <input name='group[user_ids][]' type='hidden' value='${ id }' class="group-member" >
                 <p class='chat-group-user__name'>${ name }</p>
                 <div class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</div>
               </div>`
@@ -29,12 +37,15 @@ $(function() {
   $("#user-search-field").on("keyup", function(e) {
     e.preventDefault();
     let input = $("#user-search-field").val();
+    let user_ids = [];
+    
+    addUserId(user_ids);
 
     $.ajax({
       type: 'GET',
       url: '/users',
       dataType: 'json',
-      data: { keyword: input }
+      data: { keyword: input, user_ids: user_ids }
     })
 
     .done(function(users) {
@@ -56,7 +67,7 @@ $(function() {
       let id = $(this).data('user-id');
       let name = $(this).data('user-name');
       $(this).parent().remove();
-      appendGroup(name, id);
+      GroupUser(name, id);
     });
     $(document).on("click",'.user-search-remove', function() {
       $(this).parent().remove(); 

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -39,7 +39,7 @@ $(function() {
       }
     })
     .fail(function(){
-      
+      alert("ユーザー検索に失敗しました");
     })
   });
 });

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,20 +1,29 @@
 $(function() {
   let search_list = $("#user-search-result");
+  let group_list = $("#user-group-result");
 
   function appendUser(user) {
-    let html = 
-      `<div class="chat-group-user clearfix">
-      <p class="chat-group-user__name">${ user.name }</p>
-      <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${ user.id }" data-user-name="${ user.name }">追加</div>
-      </div>`
-    search_list.append(html)
+    let html = `<div class="chat-group-user clearfix">
+                  <p class="chat-group-user__name">${ user.name }</p>
+                  <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${ user.id }" data-user-name="${ user.name }">追加</div>
+                </div>`
+    search_list.append(html);
   }
 
   function appendErrMsgToHTML(msg) {
     let html = `<div class="chat-group-user clearfix">
       <p class="chat-group-user__name">${ msg }</p>
-      </div>`;
+      </div>`
     search_list.append(html);
+  }
+
+  function appendGroup(name, id) {
+    let html = `<div class='chat-group-user'>
+                <input name='group[user_ids][]' type='hidden' value='${ id }'>
+                <p class='chat-group-user__name'>${ name }</p>
+                <div class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</div>
+              </div>`
+    group_list.append(html);
   }
 
   $("#user-search-field").on("keyup", function(e) {
@@ -37,12 +46,20 @@ $(function() {
       } else {
         appendErrMsgToHTML("ユーザーが見つかりません")
       }
-      $('#user-search-result').on('click', '.chat-group-user__btn', function(){
-
-      });
     })
     .fail(function(){
       alert("ユーザー検索に失敗しました");
+    })
+  })
+  $(function(){
+    $(document).on('click', '.user-search-add', function(){
+      let id = $(this).data('user-id');
+      let name = $(this).data('user-name');
+      $(this).parent().remove();
+      appendGroup(name, id);
+    });
+    $(document).on("click",'.user-search-remove', function() {
+      $(this).parent().remove(); 
     })
   });
 });

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,0 +1,6 @@
+$(function() {
+
+  $("#user-search-field").on("keyup", function() {
+    let input = $("#user-search-field").val();
+  });
+});

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -35,7 +35,7 @@ $(function() {
           appendUser(user);
         });
       } else {
-        ppendErrMsgToHTML("ユーザーが見つかりません")
+        appendErrMsgToHTML("ユーザーが見つかりません")
       }
     })
     .fail(function(){

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -37,6 +37,9 @@ $(function() {
       } else {
         appendErrMsgToHTML("ユーザーが見つかりません")
       }
+      $('#user-search-result').on('click', '.chat-group-user__btn', function(){
+
+      });
     })
     .fail(function(){
       alert("ユーザー検索に失敗しました");

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -2,5 +2,12 @@ $(function() {
 
   $("#user-search-field").on("keyup", function() {
     let input = $("#user-search-field").val();
+
+    $.ajax({
+      type: 'GET',
+      url: '/users',
+      dataType: 'json',
+      data: { keyword: input }
+    })
   });
 });

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,6 +1,24 @@
 $(function() {
+  let search_list = $("#user-search-result");
 
-  $("#user-search-field").on("keyup", function() {
+  function appendUser(user) {
+    let html = 
+      `<div class="chat-group-user clearfix">
+      <p class="chat-group-user__name">${ user.name }</p>
+      <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${ user.id }" data-user-name="${ user.name }">追加</div>
+      </div>`
+    search_list.append(html)
+  }
+
+  function appendErrMsgToHTML(msg) {
+    let html = `<div class="chat-group-user clearfix">
+      <p class="chat-group-user__name">${ msg }</p>
+      </div>`;
+    search_list.append(html);
+  }
+
+  $("#user-search-field").on("keyup", function(e) {
+    e.preventDefault();
     let input = $("#user-search-field").val();
 
     $.ajax({
@@ -8,6 +26,20 @@ $(function() {
       url: '/users',
       dataType: 'json',
       data: { keyword: input }
+    })
+
+    .done(function(users) {
+      $("#user-search-result").empty();
+      if (users.length !== 0) {
+        users.forEach(function(user){
+          appendUser(user);
+        });
+      } else {
+        ppendErrMsgToHTML("ユーザーが見つかりません")
+      }
+    })
+    .fail(function(){
+      
     })
   });
 });

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -17,6 +17,10 @@ class GroupsController < ApplicationController
     end
   end
 
+  def edit
+
+  end
+
   def update
     if @group.update(group_params)
       redirect_to group_messages_path(@group), notice: 'グループを編集しました'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
 
   def index
-    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").where.not(id: current_user)
     respond_to do |format|
       format.html
       format.json

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
 
   def index
-    @users = User.all
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
     respond_to do |format|
       format.html
       format.json

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,13 @@
 class UsersController < ApplicationController
 
+  def index
+    @users = User.all
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
   def edit
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
 
   def index
-    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").where.not(id: current_user)
+    @users = User.where('name LIKE(?) and (id!=?)', "%#{params[:keyword]}%","#{current_user.id}").where.not(id: params[:user_ids])
     respond_to do |format|
       format.html
       format.json

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -24,6 +24,21 @@
     .chat-group-form__field--right
       #user-group-result
 
+      .chat-group-users.js-add-user
+        .chat-group-user.clearfix.js-chat-member#chat-group-user-8
+          %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
+          %p.chat-group-user__name
+            = current_user.name
+        - group.users.each do |user|
+          - if user.id != current_user.id
+            .chat-group-user.clearfix.js-chat-member#chat-group-user-8
+              %input{name: "group[user_ids][]", type: "hidden", value: user.id}
+              %p.chat-group-user__name
+                = user.name
+              .user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn
+                削除
+                
+
   .chat-group-form__field
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -32,7 +32,7 @@
         - group.users.each do |user|
           - if user.id != current_user.id
             .chat-group-user.clearfix.js-chat-member#chat-group-user-8
-              %input{name: "group[user_ids][]", type: "hidden", value: user.id}
+              %input{name: "group[user_ids][]", type: "hidden", value: user.id, class: "group-member" }
               %p.chat-group-user__name
                 = user.name
               .user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -22,7 +22,8 @@
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-    
+      #user-group-result
+
   .chat-group-form__field
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -11,13 +11,18 @@
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
   .chat-group-form__field
-    / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+    .chat-group-form__field--right
+      .chat-group-form__search
+        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      #user-search-result
+
   .chat-group-form__field
     .chat-group-form__field--left
-      = f.label "チャットメンバー", class: "chat-group-form__label"
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
+    
   .chat-group-form__field
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/messages/_sidebar.html.haml
+++ b/app/views/messages/_sidebar.html.haml
@@ -5,7 +5,7 @@
         = current_user.name
       %ul.chat-side__header__user-box__menu
         %li.chat-side__header__user-box__menu__make-group
-          = link_to new_group_path do
+          = link_to new_group_path, data: {"turbolinks" => false} do
             = fa_icon 'edit', class: "fa-edit"
         %li.chat-side__header__user-box__menu__user-account
           = link_to edit_user_path(current_user) do

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -9,7 +9,7 @@
         - @members.each do |member|
           %li.main-header__group-box__member
             = member.name
-    = link_to edit_group_path(params[:group_id]), class: "main-header__edit-btn" do
+    = link_to edit_group_path(params[:group_id]), class: "main-header__edit-btn", data: {"turbolinks" => false}  do
       .main-header__edit-btn__text
         Edit
   .messages

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end


### PR DESCRIPTION
# What
userコントローラでjsonでの伝達経路を設定。index.json.jbuilderを作成。
userコントローラindexアクションで検察フォームに入力した情報から検索を行うように定義。その際、カレントユーザーとすでにグループに追加済のユーザーは除くように記述した。
user.jsを作成。フォームに入力した時に、keyupイベントを定義。また、追加された要素に対してのクリックイベントも定義した。
編集画面のチャットメンバーには追加済みのユーザーが表示されるようビューを編集した。

# Why
グループ作成時にインクリメンタルサーチを実装するため

# create group
![グループ作成](https://user-images.githubusercontent.com/56216409/67184480-d7e7ce00-f41e-11e9-8c8f-3e1f08b5bafd.gif)
# edit
![グループ編集](https://user-images.githubusercontent.com/56216409/67184531-f77ef680-f41e-11e9-85e8-e215cbb5d5c1.gif)
