### PR TITLE
自動更新時の取得データ修正

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -46,7 +46,7 @@
         $(".submit-btn").prop("disabled", false);
       })
     });
-    let reloadMessages = function() {
+    let reloadMessages = function(message) {
       if (window.location.href.match(/\/groups\/\d+\/messages/)) {
         if ($('.messages')[0]){
           var last_message_id = $('.messages__message:last').data('message-id');
@@ -57,7 +57,7 @@
           url: 'api/messages',
           type: 'GET', 
           dataType: 'json',
-          data: {last_message_id: last_message_id}
+          data: {last_message_id: last_message_id, id: last_message_id.id}
         })
         .done(function(messages) {
           let insertHTML = '';

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -2,7 +2,7 @@ class Api::MessagesController < ApplicationController
   def index
     @group = Group.find(params[:group_id])
     last_message_id = params[:last_message_id].to_i
-    @messages = @group.messages.includes(:user).where("id > #{last_message_id}")
+    @messages = @group.messages.includes(:user).where("id > #{last_message_id}").where.not(id: current_user.id)
     respond_to do |format|
       format.json    
       format.html


### PR DESCRIPTION
# What
自動更新で表示させるデータの取得設定から、current_user.idのものを除外した

# Why
本番環境下で画像を投稿した時に、メッセージが二重で表示されることがあることに気づいた。
原因はわからないが、もしかしたら非同期で表示されるものと、自動更新で表示されるものがたまたま被ってしまっているのかもしれない・・・と思ったため追記した。直るはわからん